### PR TITLE
Only fetch data inside challenge period (Oct 1 - May 31)

### DIFF
--- a/.github/workflows/fetch-consolidated_NHSN_HRD.yml
+++ b/.github/workflows/fetch-consolidated_NHSN_HRD.yml
@@ -9,7 +9,7 @@ on:
 # |  |  |  |  |
 # *  *  *  *  *  command to be executed
   schedule:
-    - cron: '0 12 * * 0' # Runs every Sunday at 8:00 AM EDT (12:00 PM UTC)
+    - cron: '0 12 * 10-5 0' # Runs every Sunday at 8:00 AM EDT (12:00 PM UTC)
   workflow_dispatch:      # Allows manual triggering
 
 permissions:

--- a/.github/workflows/fetch-preliminary_NHSN_HRD.yml
+++ b/.github/workflows/fetch-preliminary_NHSN_HRD.yml
@@ -9,7 +9,7 @@ on:
 # |  |  |  |  |
 # *  *  *  *  *  command to be executed
   schedule:
-    - cron: '0 18 * * 3' # Runs every Wednesday at 1:00 PM EDT (6:00 PM UTC)
+    - cron: '0 18 * 10-5 3' # Runs every Wednesday at 1:00 PM EDT (6:00 PM UTC)
   workflow_dispatch:      # Allows manual triggering
 
 permissions:


### PR DESCRIPTION
As I move towards the automatic upload to the CDC FluSight GH repository, limit fetching of data to period October 1 - May 31 (challenge period October 15 until May 20).