### PR TITLE
Rectify forecast 2025-11-29 

### DIFF
--- a/data/interim/calibration/forecast/SIR-1S/hyperparameters-exclude_None/2025-11-29-Cornell_JHU-hierarchSIR.csv
+++ b/data/interim/calibration/forecast/SIR-1S/hyperparameters-exclude_None/2025-11-29-Cornell_JHU-hierarchSIR.csv
@@ -21,12 +21,12 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,-1,US,quantile,0.9,3409.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,US,quantile,0.95,3479.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,US,quantile,0.975,3542.1749999999997,2025-11-22
-2025-11-29,wk inc flu hosp,-1,US,quantile,0.99,3619.0699999999997,2025-11-22
+2025-11-29,wk inc flu hosp,-1,US,quantile,0.99,3619.07,2025-11-22
 2025-11-29,wk inc flu hosp,0,US,quantile,0.01,3430.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.025,3506.8250000000003,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.05,3583.65,2025-11-29
-2025-11-29,wk inc flu hosp,0,US,quantile,0.1,3709.2999999999997,2025-11-29
-2025-11-29,wk inc flu hosp,0,US,quantile,0.15,3792.9500000000003,2025-11-29
+2025-11-29,wk inc flu hosp,0,US,quantile,0.1,3709.3,2025-11-29
+2025-11-29,wk inc flu hosp,0,US,quantile,0.15,3792.95,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.2,3885.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.25,3941.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.3,3997.0,2025-11-29
@@ -45,8 +45,8 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,0,US,quantile,0.95,4844.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.975,4949.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,US,quantile,0.99,5096.0,2025-11-29
-2025-11-29,wk inc flu hosp,1,US,quantile,0.01,3842.5800000000004,2025-12-06
-2025-11-29,wk inc flu hosp,1,US,quantile,0.025,3989.8250000000003,2025-12-06
+2025-11-29,wk inc flu hosp,1,US,quantile,0.01,3842.58,2025-12-06
+2025-11-29,wk inc flu hosp,1,US,quantile,0.025,3989.825,2025-12-06
 2025-11-29,wk inc flu hosp,1,US,quantile,0.05,4137.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,US,quantile,0.1,4382.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,US,quantile,0.15,4487.0,2025-12-06
@@ -104,16 +104,16 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,US,quantile,0.45,8820.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.5,9023.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.55,9205.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,US,quantile,0.6,9410.800000000001,2025-12-20
+2025-11-29,wk inc flu hosp,3,US,quantile,0.6,9410.8,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.65,9611.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.7,9849.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.75,10045.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.8,10297.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,US,quantile,0.85,10606.050000000001,2025-12-20
-2025-11-29,wk inc flu hosp,3,US,quantile,0.9,11130.699999999999,2025-12-20
+2025-11-29,wk inc flu hosp,3,US,quantile,0.85,10606.05,2025-12-20
+2025-11-29,wk inc flu hosp,3,US,quantile,0.9,11130.7,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.95,11802.35,2025-12-20
 2025-11-29,wk inc flu hosp,3,US,quantile,0.975,12467.875,2025-12-20
-2025-11-29,wk inc flu hosp,3,US,quantile,0.99,13314.279999999999,2025-12-20
+2025-11-29,wk inc flu hosp,3,US,quantile,0.99,13314.28,2025-12-20
 2025-11-29,wk inc flu hosp,-1,01,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,01,quantile,0.025,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,01,quantile,0.05,7.0,2025-11-22
@@ -734,7 +734,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,0,08,quantile,0.9,140.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,08,quantile,0.95,154.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,08,quantile,0.975,168.0,2025-11-29
-2025-11-29,wk inc flu hosp,0,08,quantile,0.99,182.06999999999994,2025-11-29
+2025-11-29,wk inc flu hosp,0,08,quantile,0.99,182.0699999999999,2025-11-29
 2025-11-29,wk inc flu hosp,1,08,quantile,0.01,35.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,08,quantile,0.025,42.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,08,quantile,0.05,56.0,2025-12-06
@@ -757,7 +757,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,1,08,quantile,0.9,168.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,08,quantile,0.95,189.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,08,quantile,0.975,210.0,2025-12-06
-2025-11-29,wk inc flu hosp,1,08,quantile,0.99,238.06999999999994,2025-12-06
+2025-11-29,wk inc flu hosp,1,08,quantile,0.99,238.0699999999999,2025-12-06
 2025-11-29,wk inc flu hosp,2,08,quantile,0.01,48.93,2025-12-13
 2025-11-29,wk inc flu hosp,2,08,quantile,0.025,56.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,08,quantile,0.05,70.0,2025-12-13
@@ -1220,7 +1220,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,1,12,quantile,0.99,777.0699999999999,2025-12-06
 2025-11-29,wk inc flu hosp,2,12,quantile,0.01,300.93,2025-12-13
 2025-11-29,wk inc flu hosp,2,12,quantile,0.025,342.825,2025-12-13
-2025-11-29,wk inc flu hosp,2,12,quantile,0.05,363.65000000000003,2025-12-13
+2025-11-29,wk inc flu hosp,2,12,quantile,0.05,363.65,2025-12-13
 2025-11-29,wk inc flu hosp,2,12,quantile,0.1,392.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,12,quantile,0.15,413.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,12,quantile,0.2,434.0,2025-12-13
@@ -1262,7 +1262,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,12,quantile,0.85,833.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,12,quantile,0.9,868.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,12,quantile,0.95,945.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,12,quantile,0.975,1036.1749999999997,2025-12-20
+2025-11-29,wk inc flu hosp,3,12,quantile,0.975,1036.1749999999995,2025-12-20
 2025-11-29,wk inc flu hosp,3,12,quantile,0.99,1113.0,2025-12-20
 2025-11-29,wk inc flu hosp,-1,13,quantile,0.01,20.93,2025-11-22
 2025-11-29,wk inc flu hosp,-1,13,quantile,0.025,28.0,2025-11-22
@@ -1585,7 +1585,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,16,quantile,0.9,154.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,16,quantile,0.95,175.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,16,quantile,0.975,196.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,16,quantile,0.99,224.06999999999994,2025-12-13
+2025-11-29,wk inc flu hosp,2,16,quantile,0.99,224.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,16,quantile,0.01,21.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,16,quantile,0.025,28.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,16,quantile,0.05,35.0,2025-12-20
@@ -1654,7 +1654,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,0,17,quantile,0.9,175.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,17,quantile,0.95,196.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,17,quantile,0.975,224.0,2025-11-29
-2025-11-29,wk inc flu hosp,0,17,quantile,0.99,238.06999999999994,2025-11-29
+2025-11-29,wk inc flu hosp,0,17,quantile,0.99,238.0699999999999,2025-11-29
 2025-11-29,wk inc flu hosp,1,17,quantile,0.01,35.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,17,quantile,0.025,49.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,17,quantile,0.05,63.0,2025-12-06
@@ -1723,7 +1723,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,17,quantile,0.9,581.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,17,quantile,0.95,707.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,17,quantile,0.975,861.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,17,quantile,0.99,1001.0699999999999,2025-12-20
+2025-11-29,wk inc flu hosp,3,17,quantile,0.99,1001.07,2025-12-20
 2025-11-29,wk inc flu hosp,-1,18,quantile,0.01,7.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,18,quantile,0.025,14.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,18,quantile,0.05,14.0,2025-11-22
@@ -2183,7 +2183,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,21,quantile,0.9,140.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,21,quantile,0.95,168.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,21,quantile,0.975,189.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,21,quantile,0.99,238.06999999999994,2025-12-20
+2025-11-29,wk inc flu hosp,3,21,quantile,0.99,238.0699999999999,2025-12-20
 2025-11-29,wk inc flu hosp,-1,22,quantile,0.01,49.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,22,quantile,0.025,56.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,22,quantile,0.05,63.0,2025-11-22
@@ -2336,7 +2336,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,0,23,quantile,0.5,0.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,23,quantile,0.55,0.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,23,quantile,0.6,0.0,2025-11-29
-2025-11-29,wk inc flu hosp,0,23,quantile,0.65,-3.885780586188048e-16,2025-11-29
+2025-11-29,wk inc flu hosp,0,23,quantile,0.65,0.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,23,quantile,0.7,7.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,23,quantile,0.75,7.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,23,quantile,0.8,7.0,2025-11-29
@@ -2712,7 +2712,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,1,26,quantile,0.9,147.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,26,quantile,0.95,175.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,26,quantile,0.975,196.17499999999984,2025-12-06
-2025-11-29,wk inc flu hosp,1,26,quantile,0.99,238.06999999999994,2025-12-06
+2025-11-29,wk inc flu hosp,1,26,quantile,0.99,238.0699999999999,2025-12-06
 2025-11-29,wk inc flu hosp,2,26,quantile,0.01,28.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,26,quantile,0.025,35.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,26,quantile,0.05,49.0,2025-12-13
@@ -2850,7 +2850,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,27,quantile,0.9,112.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,27,quantile,0.95,133.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,27,quantile,0.975,161.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,27,quantile,0.99,182.06999999999994,2025-12-13
+2025-11-29,wk inc flu hosp,2,27,quantile,0.99,182.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,27,quantile,0.01,7.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,27,quantile,0.025,14.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,27,quantile,0.05,28.0,2025-12-20
@@ -3677,7 +3677,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,34,quantile,0.85,602.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,34,quantile,0.9,672.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,34,quantile,0.95,798.3499999999997,2025-12-20
-2025-11-29,wk inc flu hosp,3,34,quantile,0.975,924.3499999999997,2025-12-20
+2025-11-29,wk inc flu hosp,3,34,quantile,0.975,924.3499999999996,2025-12-20
 2025-11-29,wk inc flu hosp,3,34,quantile,0.99,1078.2099999999998,2025-12-20
 2025-11-29,wk inc flu hosp,-1,35,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,35,quantile,0.025,0.0,2025-11-22
@@ -3770,7 +3770,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,35,quantile,0.9,105.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,35,quantile,0.95,133.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,35,quantile,0.975,168.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,35,quantile,0.99,189.06999999999994,2025-12-13
+2025-11-29,wk inc flu hosp,2,35,quantile,0.99,189.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,35,quantile,0.01,0.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,35,quantile,0.025,0.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,35,quantile,0.05,7.0,2025-12-20
@@ -3861,7 +3861,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,1,36,quantile,0.85,889.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,36,quantile,0.9,938.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,36,quantile,0.95,1015.0,2025-12-06
-2025-11-29,wk inc flu hosp,1,36,quantile,0.975,1092.1749999999997,2025-12-06
+2025-11-29,wk inc flu hosp,1,36,quantile,0.975,1092.1749999999995,2025-12-06
 2025-11-29,wk inc flu hosp,1,36,quantile,0.99,1211.0,2025-12-06
 2025-11-29,wk inc flu hosp,2,36,quantile,0.01,510.86,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.025,538.8249999999999,2025-12-13
@@ -3881,7 +3881,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,36,quantile,0.7,1204.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.75,1274.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.8,1337.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,36,quantile,0.85,1415.0499999999997,2025-12-13
+2025-11-29,wk inc flu hosp,2,36,quantile,0.85,1415.0499999999995,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.9,1526.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.95,1708.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,36,quantile,0.975,1925.0,2025-12-13
@@ -3900,7 +3900,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,36,quantile,0.5,1617.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,36,quantile,0.55,1687.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,36,quantile,0.6,1764.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,36,quantile,0.65,1843.4500000000003,2025-12-20
+2025-11-29,wk inc flu hosp,3,36,quantile,0.65,1843.4500000000005,2025-12-20
 2025-11-29,wk inc flu hosp,3,36,quantile,0.7,1925.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,36,quantile,0.75,2002.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,36,quantile,0.8,2163.0,2025-12-20
@@ -4002,7 +4002,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,37,quantile,0.975,525.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,37,quantile,0.99,588.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,37,quantile,0.01,202.93,2025-12-20
-2025-11-29,wk inc flu hosp,3,37,quantile,0.025,237.82500000000002,2025-12-20
+2025-11-29,wk inc flu hosp,3,37,quantile,0.025,237.825,2025-12-20
 2025-11-29,wk inc flu hosp,3,37,quantile,0.05,259.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,37,quantile,0.1,287.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,37,quantile,0.15,315.0,2025-12-20
@@ -4023,7 +4023,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,37,quantile,0.9,749.7000000000002,2025-12-20
 2025-11-29,wk inc flu hosp,3,37,quantile,0.95,847.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,37,quantile,0.975,910.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,37,quantile,0.99,1078.1399999999999,2025-12-20
+2025-11-29,wk inc flu hosp,3,37,quantile,0.99,1078.14,2025-12-20
 2025-11-29,wk inc flu hosp,-1,38,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,38,quantile,0.025,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,38,quantile,0.05,0.0,2025-11-22
@@ -4184,7 +4184,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,0,39,quantile,0.9,175.0,2025-11-29
 2025-11-29,wk inc flu hosp,0,39,quantile,0.95,189.34999999999968,2025-11-29
 2025-11-29,wk inc flu hosp,0,39,quantile,0.975,217.0,2025-11-29
-2025-11-29,wk inc flu hosp,0,39,quantile,0.99,238.06999999999994,2025-11-29
+2025-11-29,wk inc flu hosp,0,39,quantile,0.99,238.0699999999999,2025-11-29
 2025-11-29,wk inc flu hosp,1,39,quantile,0.01,42.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,39,quantile,0.025,56.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,39,quantile,0.05,63.0,2025-12-06
@@ -4253,7 +4253,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,39,quantile,0.9,574.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,39,quantile,0.95,672.3499999999997,2025-12-20
 2025-11-29,wk inc flu hosp,3,39,quantile,0.975,798.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,39,quantile,0.99,903.0699999999999,2025-12-20
+2025-11-29,wk inc flu hosp,3,39,quantile,0.99,903.07,2025-12-20
 2025-11-29,wk inc flu hosp,-1,40,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,40,quantile,0.025,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,40,quantile,0.05,0.0,2025-11-22
@@ -4573,8 +4573,8 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,42,quantile,0.8,609.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,42,quantile,0.85,658.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,42,quantile,0.9,742.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,42,quantile,0.95,910.3499999999997,2025-12-13
-2025-11-29,wk inc flu hosp,2,42,quantile,0.975,1015.3499999999997,2025-12-13
+2025-11-29,wk inc flu hosp,2,42,quantile,0.95,910.3499999999996,2025-12-13
+2025-11-29,wk inc flu hosp,2,42,quantile,0.975,1015.3499999999996,2025-12-13
 2025-11-29,wk inc flu hosp,2,42,quantile,0.99,1078.0,2025-12-13
 2025-11-29,wk inc flu hosp,3,42,quantile,0.01,196.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.025,265.825,2025-12-20
@@ -4595,7 +4595,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,42,quantile,0.75,868.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.8,931.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.85,1008.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,42,quantile,0.9,1120.7000000000003,2025-12-20
+2025-11-29,wk inc flu hosp,3,42,quantile,0.9,1120.7000000000005,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.95,1337.3499999999997,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.975,1582.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,42,quantile,0.99,1806.0,2025-12-20
@@ -5035,7 +5035,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,47,quantile,0.9,147.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,47,quantile,0.95,175.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,47,quantile,0.975,189.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,47,quantile,0.99,231.06999999999994,2025-12-13
+2025-11-29,wk inc flu hosp,2,47,quantile,0.99,231.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,47,quantile,0.01,28.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,47,quantile,0.025,35.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,47,quantile,0.05,42.0,2025-12-20
@@ -5149,7 +5149,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,48,quantile,0.85,770.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,48,quantile,0.9,840.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,48,quantile,0.95,966.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,48,quantile,0.975,1092.1749999999997,2025-12-13
+2025-11-29,wk inc flu hosp,2,48,quantile,0.975,1092.1749999999995,2025-12-13
 2025-11-29,wk inc flu hosp,2,48,quantile,0.99,1267.07,2025-12-13
 2025-11-29,wk inc flu hosp,3,48,quantile,0.01,315.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,48,quantile,0.025,356.825,2025-12-20
@@ -5170,10 +5170,10 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,48,quantile,0.75,918.75,2025-12-20
 2025-11-29,wk inc flu hosp,3,48,quantile,0.8,1001.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,48,quantile,0.85,1085.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,48,quantile,0.9,1211.7000000000003,2025-12-20
+2025-11-29,wk inc flu hosp,3,48,quantile,0.9,1211.7000000000005,2025-12-20
 2025-11-29,wk inc flu hosp,3,48,quantile,0.95,1393.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,48,quantile,0.975,1582.5249999999996,2025-12-20
-2025-11-29,wk inc flu hosp,3,48,quantile,0.99,1841.2799999999997,2025-12-20
+2025-11-29,wk inc flu hosp,3,48,quantile,0.99,1841.2799999999995,2025-12-20
 2025-11-29,wk inc flu hosp,-1,49,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,49,quantile,0.025,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,49,quantile,0.05,0.0,2025-11-22
@@ -5288,7 +5288,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,3,49,quantile,0.9,70.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,49,quantile,0.95,91.34999999999968,2025-12-20
 2025-11-29,wk inc flu hosp,3,49,quantile,0.975,133.0,2025-12-20
-2025-11-29,wk inc flu hosp,3,49,quantile,0.99,203.06999999999994,2025-12-20
+2025-11-29,wk inc flu hosp,3,49,quantile,0.99,203.0699999999999,2025-12-20
 2025-11-29,wk inc flu hosp,-1,50,quantile,0.01,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,50,quantile,0.025,0.0,2025-11-22
 2025-11-29,wk inc flu hosp,-1,50,quantile,0.05,0.0,2025-11-22
@@ -5495,7 +5495,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,51,quantile,0.9,147.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,51,quantile,0.95,161.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,51,quantile,0.975,175.17499999999984,2025-12-13
-2025-11-29,wk inc flu hosp,2,51,quantile,0.99,210.06999999999994,2025-12-13
+2025-11-29,wk inc flu hosp,2,51,quantile,0.99,210.0699999999999,2025-12-13
 2025-11-29,wk inc flu hosp,3,51,quantile,0.01,28.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,51,quantile,0.025,42.0,2025-12-20
 2025-11-29,wk inc flu hosp,3,51,quantile,0.05,56.0,2025-12-20
@@ -5587,7 +5587,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,1,53,quantile,0.9,112.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,53,quantile,0.95,133.0,2025-12-06
 2025-11-29,wk inc flu hosp,1,53,quantile,0.975,168.0,2025-12-06
-2025-11-29,wk inc flu hosp,1,53,quantile,0.99,189.06999999999994,2025-12-06
+2025-11-29,wk inc flu hosp,1,53,quantile,0.99,189.0699999999999,2025-12-06
 2025-11-29,wk inc flu hosp,2,53,quantile,0.01,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,53,quantile,0.025,14.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,53,quantile,0.05,21.0,2025-12-13
@@ -5821,7 +5821,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,55,quantile,0.01,0.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,55,quantile,0.025,0.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,55,quantile,0.05,0.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,55,quantile,0.1,7.771561172376096e-16,2025-12-13
+2025-11-29,wk inc flu hosp,2,55,quantile,0.1,7.771561172376097e-16,2025-12-13
 2025-11-29,wk inc flu hosp,2,55,quantile,0.15,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,55,quantile,0.2,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,55,quantile,0.25,14.0,2025-12-13


### PR DESCRIPTION
Most likely, a rounding error in the computation of the quantiles caused a forecasted value to be slightly negative, which is picked up by the CDC FluSight challenge submission validation. This PR only rectifies the forecast made on 2025-11-29.