### PR TITLE
Fix monotonically increasing issue

### DIFF
--- a/data/interim/calibration/forecast/SIR-1S/hyperparameters-exclude_None/2025-11-29-Cornell_JHU-hierarchSIR.csv
+++ b/data/interim/calibration/forecast/SIR-1S/hyperparameters-exclude_None/2025-11-29-Cornell_JHU-hierarchSIR.csv
@@ -4330,7 +4330,7 @@ reference_date,target,horizon,location,output_type,output_type_id,value,target_e
 2025-11-29,wk inc flu hosp,2,40,quantile,0.15,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,40,quantile,0.2,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,40,quantile,0.25,7.0,2025-12-13
-2025-11-29,wk inc flu hosp,2,40,quantile,0.3,6.999999999999999,2025-12-13
+2025-11-29,wk inc flu hosp,2,40,quantile,0.3,7.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,40,quantile,0.35,14.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,40,quantile,0.4,14.0,2025-12-13
 2025-11-29,wk inc flu hosp,2,40,quantile,0.45,14.0,2025-12-13


### PR DESCRIPTION
Previous fix probably caused a 7.0 to be rounded to 6.9999999 making the forecasts not monotonically increasing upon submission.