### PR TITLE
Bugfix upon bump from numpy 2.3.5 to 2.4.0

### DIFF
--- a/src/hierarchSIR/model.py
+++ b/src/hierarchSIR/model.py
@@ -96,10 +96,10 @@ class imsSIR():
             # get parameters
             if draw_function:
                 self.parameters.update(draw_function(copy.deepcopy(self.parameters), **draw_function_kwargs))
-            # make sure parameters are vectors #TODO: do better!
-            for par, shape in self.parameter_shapes.items():
-                if ((shape == (1,)) & (par not in ['rho_i', 'T_h', 'gamma', 'sigma', 'modifier_length']) & (par != 'delta_beta_temporal')):
-                    self.parameters[par] = np.array([self.parameters[par],])
+            # make sure the necessary parameters are vectors
+            for par, _ in self.parameter_shapes.items():
+                if par in ['beta', 'rho_h']:
+                    self.parameters[par] = np.atleast_1d(self.parameters[par])
             # build initial condition
             self.initial_condition = self.ICF(*[self.parameters[par] for par in self.ICF_args_names])
             # remove ICF arguments from the parameters


### PR DESCRIPTION
When bumping from numpy 2.3.5 to 2.4.0 the following error stack appeared in the automation:

```
Working on forecast in US state USA with hyperparameters exclude_None
Traceback (most recent call last):
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.12/site-packages/pySODM/optimization/objective_functions.py", line 1516, in validate_simulation
    model.sim([start_sim, end_sim], **simulation_kwargs)
  File "/home/twallema/actions-runner/_work/Cornell_JHU-hierarchSIR/Cornell_JHU-hierarchSIR/src/hierarchSIR/model.py", line 108, in sim
    simout = sir_model.integrate(*time, atol, rtol, **self.initial_condition, **self.parameters)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: integrate(): incompatible function arguments. The following argument types are supported:
    1. (t_start: typing.SupportsFloat, t_end: typing.SupportsFloat, atol: typing.SupportsFloat, rtol: typing.SupportsFloat, S0: collections.abc.Sequence[typing.SupportsFloat], I0: collections.abc.Sequence[typing.SupportsFloat], R0: collections.abc.Sequence[typing.SupportsFloat], beta: collections.abc.Sequence[typing.SupportsFloat], gamma: collections.abc.Sequence[typing.SupportsFloat], rho_i: typing.SupportsFloat, rho_h: collections.abc.Sequence[typing.SupportsFloat], T_h: typing.SupportsFloat, delta_beta_temporal: collections.abc.Sequence[typing.SupportsFloat], modifier_length: typing.SupportsInt, sigma: typing.SupportsFloat) -> list[list[float]]

Invoked with: -44, 66, 0.01, 1e-05; kwargs: S0=array([[2.16817206e+08]]), I0=array([[33361.6258]]), R0=array([[1.1676569e+08]]), beta=array([[0.5]]), gamma=array([0.28571429]), delta_beta_temporal=array([ 0.5, -0.5,  0.5, -0.5,  0.5, -0.5,  0.5, -0.5,  0.5, -0.5,  0.5,
       -0.5]), modifier_length=15, sigma=2.5, rho_i=0.025, rho_h=array([[0.025]]), T_h=2.0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/twallema/actions-runner/_work/Cornell_JHU-hierarchSIR/Cornell_JHU-hierarchSIR/scripts/operational/forecast.py", line 156, in <module>
    lpp = log_posterior_probability(model, pars, bounds, data_calib, states, log_likelihood_fnc, log_likelihood_fnc_args,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.12/site-packages/pySODM/optimization/objective_functions.py", line 213, in __init__
    validate_simulation(model, simulation_kwargs, self.start_sim, self.end_sim)
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.12/site-packages/pySODM/optimization/objective_functions.py", line 1518, in validate_simulation
    raise ValueError(f"the attempt to simulate your pySODM model between '{start_sim}' and '{end_sim}' with simulation_kwargs: '{simulation_kwargs}' failed. consult the error stack to find and resolve the simulation error.")
ValueError: the attempt to simulate your pySODM model between '2025-09-01 00:00:00' and '2025-12-20 00:00:00' with simulation_kwargs: '{}' failed. consult the error stack to find and resolve the simulation error.
Error: Process completed with exit code 1.
```

This bug resolves this error but long-term all references to strain-stratification should be removed from this repository ideally.