### PR TITLE
Add negative binomial resampling noise instead of poisson noise

### DIFF
--- a/scripts/operational/forecast.py
+++ b/scripts/operational/forecast.py
@@ -222,7 +222,7 @@ if __name__ == '__main__':
         
         # Add sampling noise
         try:
-            simout = add_negative_binomial_noise(simout+0.01, 0.01)
+            simout = add_negative_binomial_noise(simout+0.01, 0.01) # motivation for choosing 0.01 --> Does not increase noise much for most states, but relaxes "overconfident" forecasts a bit improving WIS
         except:
             print('no negative binomial resampling performed')
             sys.stdout.flush()


### PR DESCRIPTION
Use a negative binomial resampling to add observation noise with phi = 0.01.

This actually doesn't alter the width of uncertainty intervals too much for models that already have a lot of process noise, while relaxing the uncertainty cone somewhat in "overconfident" states.

I think this may prove valuable to buffer slightly against "overconfident" forecasts.