### PR TITLE
Tighten perturbation in NM

### DIFF
--- a/scripts/operational/forecast.py
+++ b/scripts/operational/forecast.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
         #################
 
         # perform optimization 
-        theta, _ = nelder_mead.optimize(lpp, np.array(theta), len(lpp.expanded_bounds)*[0.2,],
+        theta, _ = nelder_mead.optimize(lpp, np.array(theta), len(lpp.expanded_bounds)*[0.1,],
                                         processes=processes, max_iter=n_nm, no_improv_break=1000)
 
         ######################


### PR DESCRIPTION
From 0.2 --> 0.1 because automated forecasts failed with

```

Nelder-Mead minimization
========================

For 1000 iterations using 4 cores
Starting point: [ 1.07567824e-02  3.81481716e-01  1.11808277e-04  4.89309340e-01
  8.66239096e-02  1.03038046e-01  8.33241246e-02  1.03040761e-01
  2.46685512e-01 -4.81422983e-02  4.69939828e-02  6.77638974e-02
  3.35066540e-02  1.45405920e-02 -8.62859261e-03  1.02223085e-02]
Bounds: [(0, 0.02), (0, 1), (1e-09, 0.01), (0.3, 0.6), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5), (-0.5, 0.5)]

Traceback (most recent call last):
  File "/home/twallema/actions-runner/_work/Cornell_JHU-hierarchSIR/Cornell_JHU-hierarchSIR/scripts/operational/forecast.py", line 165, in <module>
    theta, _ = nelder_mead.optimize(lpp, np.array(theta), len(lpp.expanded_bounds)*[0.2,],
               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                    processes=processes, max_iter=n_nm, no_improv_break=1000)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.14/site-packages/pySODM/optimization/nelder_mead.py", line 121, in optimize
    prev_best = obj(x_start)
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.14/site-packages/pySODM/optimization/nelder_mead.py", line 17, in _obj_wrapper
    return -func(x, *args, **kwargs)
            ~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.14/site-packages/pySODM/optimization/objective_functions.py", line 321, in __call__
    lp += self.compute_log_likelihood(out, self.states[idx], df, self.weights[idx], self.log_likelihood_fnc[idx], self.log_likelihood_fnc_args[idx],
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                      self.time_index, self.n_log_likelihood_extra_args[idx], self.aggregate_over[idx], self.additional_axes_data[idx],
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                      self.coordinates_data_also_in_model[idx], self.aggregation_function[idx])
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/twallema/miniconda3/envs/BENTOLAB-HIERARCHSIR/lib/python3.14/site-packages/pySODM/optimization/objective_functions.py", line 265, in compute_log_likelihood
    raise ValueError(f"simulation output contains nan, likely due to numerical unstability. try using more conservative bounds.")
ValueError: simulation output contains nan, likely due to numerical unstability. try using more conservative bounds.
```