### PR TITLE
Fix xarray no longer interpolating between datetime64[us] and datetime64[ns]

### DIFF
--- a/scripts/operational/forecast.py
+++ b/scripts/operational/forecast.py
@@ -123,6 +123,13 @@ if __name__ == '__main__':
         # format data
         data, states, log_likelihood_fnc, log_likelihood_fnc_args = make_data_pySODM_compatible(start_simulation, datetime(3000, 1, 1), fips_state, type='preliminary_backfilled')
 
+        # reformat data to use microseconds
+        # added because interpolation from simulation dates to data dates in the computation of the log posterior probability function of pySODM, which is done with an xarray interp function, no longer happily juggles ns and us
+        # I strongly suggest making sure the xarray simulation output in pySODM enforces [ns]
+        d = data[0]
+        d.index = d.index.astype("datetime64[us]")
+        data[0] = d
+
         #################
         ## Setup model ##
         #################


### PR DESCRIPTION
The following xarray interpolation, which interpolates the simulation dates to match the data dates in the log posterior probability function of pySODM, no longer happily converts between datetime64[ns] (the default for data) and datetime64[us] (the default used by pySODM).

```
interp = out_copy.interp({time_index: df.index.get_level_values(time_index).unique().values}, method="linear")
```

I have added a temporary patch to the `forecast.py` that converts the data to datetime64[us] to avoid this error. However, a long term fix should be to downcast datetime64[us] to datetime64[ns] in the function `_output_to_xarray_dataset` of the `models/base.py` module of pySODM. 

I suggest replacing the pure python datetimes, which have microseconds as their maximum resolution,
```
v_acc = [[
    start_date + timedelta(microseconds=float(i*time_unit_map[time_unit]))
    for i in output["t"]
],] + v_acc

```

with numpy datetimes in nanoseconds to match pandas default ns,

```
times_py = [
    start_date + timedelta(microseconds=float(i * time_unit_map[time_unit]))
    for i in output["t"]
]

times_ns = np.array(times_py, dtype="datetime64[ns]")

v_acc = [times_ns] + v_acc
```